### PR TITLE
Fix duplicates for overriding a method with [RequiresSuper] attribute

### DIFF
--- a/src/Xamarin.CodeAnalysis/Apple/AttributeAnalyzer.cs
+++ b/src/Xamarin.CodeAnalysis/Apple/AttributeAnalyzer.cs
@@ -186,7 +186,12 @@ namespace Xamarin.CodeAnalysis.Apple
             {
                 if (attr.AttributeClass == adviceAttribute && attr.ConstructorArguments.Length > 0)
                 {
-                    AddIssue(context, adviceRule, attr.ConstructorArguments[0].Value?.ToString());
+                    var message = attr.ConstructorArguments[0].Value?.ToString();
+
+                    if (message.Equals("Overriding this method requires a call to the overriden method."))
+                        continue;
+
+                    AddIssue(context, adviceRule, message);
                 }
                 else
                 {


### PR DESCRIPTION
https://github.com/xamarin/xamarin-macios/issues/7823

Currently there are two Xamarin.iOS analyzers in https://github.com/xamarin/CodeAnalysis/tree/master/src/Xamarin.CodeAnalysis/Apple
They both populate intellisense for the `[RequiresSuper]` attribute. XIA1001 detects all Advice attributes, XIA1004 specifically for the `[RequiresSuper]` attribute. As a result, there are two things populated for `[RequiresSuper]`. These two analyzers will be bundled into the same nuget package.

Some more detail:

XIA1004 looks for the `[RequiresSuper]` attribute and _checks_ whether or not the method contains the correct base call. If it does not, the analyzer adds an issue w/ an option to "fix" and add the base call.

XIA1001 looks for any advice attribute and adds an info issue to the base call, even when the method is using the base call correctly.

The issue is where the user sees XIA1004, applies the fix (or manually adds the base call), and then sees info issue XIA1001 even with the correct base call.

<img width="819" alt="Screen Shot 2020-02-11 at 3 27 38 PM" src="https://user-images.githubusercontent.com/51677938/74276299-760be680-4ce3-11ea-99cf-7b3c46540e80.png">

- XIA1004 recommends a fix to add the base call

<img width="809" alt="Screen Shot 2020-02-11 at 3 27 55 PM" src="https://user-images.githubusercontent.com/51677938/74276311-799f6d80-4ce3-11ea-8cb6-394ad767c50a.png">

- The user applies the recommended fix from XIA1004, which adds the base call

<img width="827" alt="Screen Shot 2020-02-11 at 3 28 12 PM" src="https://user-images.githubusercontent.com/51677938/74276329-81f7a880-4ce3-11ea-8293-0c98489c3c3d.png">

- XIA1001 recommends checking that the override contains the correct call to the overriding method

I've tested the NuGet pkg on VSMac + VS.

For context, XIA1001-1003 were added as the initial MaciOS analyzer and XIA1004 was an enhancement that was added later by our extern.