### PR TITLE
Migrate to use the MicroBuild scaleset pool: VSEngSS-MicroBuild2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,21 @@
-queue: VSEngSS-MicroBuild2019
+trigger:
+  branches:
+    include:
+    - master
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+
+jobs:
+- job: Build
+  timeoutInMinutes: 10
+  pool:
+    name: VSEngSS-MicroBuild2019
 
 steps:
-
 - checkout: self
   clean: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ trigger:
     - master
 
 pr:
-  autoCancel: true
+  autoCancel: false
   branches:
     include:
     - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
 - job: Build
   timeoutInMinutes: 10
   pool:
-    name: VSEngSS-MicroBuild2019
+    vmImage: 'windows-2019'
 
 steps:
 - checkout: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-queue: VSEng-MicroBuildVS2019
+queue: VSEngSS-MicroBuild2019
 
 steps:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,36 +15,36 @@ jobs:
   pool:
     vmImage: 'windows-2019'
 
-steps:
-- checkout: self
-  clean: true
+  steps:
+  - checkout: self
+    clean: true
 
-- task: MSBuild@1
-  displayName: Restore
-  inputs:
-    solution: Xamarin.CodeAnalysis.sln
-    configuration: Release
-    msbuildArguments: /t:Restore /bl:"$(Build.ArtifactStagingDirectory)\restore.binlog" /m
+  - task: MSBuild@1
+    displayName: Restore
+    inputs:
+      solution: Xamarin.CodeAnalysis.sln
+      configuration: Release
+      msbuildArguments: /t:Restore /bl:"$(Build.ArtifactStagingDirectory)\restore.binlog" /m
 
-- task: MSBuild@1
-  displayName: Build
-  inputs:
-    solution: Xamarin.CodeAnalysis.sln
-    configuration: Release
-    msbuildArguments: /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:TargetVsixContainer=$(Build.ArtifactStagingDirectory)\Xamarin.CodeAnalysis.vsix /m
+  - task: MSBuild@1
+    displayName: Build
+    inputs:
+      solution: Xamarin.CodeAnalysis.sln
+      configuration: Release
+      msbuildArguments: /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:TargetVsixContainer=$(Build.ArtifactStagingDirectory)\Xamarin.CodeAnalysis.vsix /m
 
-- task: VSTest@2
-  displayName: Test
-  inputs:
-    testAssemblyVer2: src\*\bin\*\*.Tests.dll
-    runInParallel: 'true'
-    codeCoverageEnabled: 'true'
-    publishRunAttachments: 'true'
+  - task: VSTest@2
+    displayName: Test
+    inputs:
+      testAssemblyVer2: src\*\bin\*\*.Tests.dll
+      runInParallel: 'true'
+      codeCoverageEnabled: 'true'
+      publishRunAttachments: 'true'
 
-- task: PublishBuildArtifacts@1
-  displayName: Publish Artifact
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)
-    ArtifactName: out
-    ArtifactType: Container
-  condition: always()
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Artifact
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)
+      ArtifactName: out
+      ArtifactType: Container
+    condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,11 @@ jobs:
   - checkout: self
     clean: true
 
+  - task: NuGetAuthenticate@0
+    displayName: Authenticate NuGet feeds
+    inputs:
+      forceReinstallCredentialProvider: true
+
   - task: MSBuild@1
     displayName: Restore
     inputs:

--- a/src/Packages.props
+++ b/src/Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <RoslynVersion>3.0.0-beta4-19165-02</RoslynVersion>
+    <RoslynVersion>3.7.0-3.20271.4</RoslynVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="[$(RoslynVersion)]" />
     <PackageReference Update="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="[$(RoslynVersion)]" />
-    <PackageReference Update="Microsoft.CodeAnalysis.Remote.Workspaces" Version="[$(RoslynVersion)]" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Features" Version="[$(RoslynVersion)]" />
     <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="[15.9.3039]" />
     <PackageReference Update="Xamarin.VSSDK.BuildTools" Version="[0.3.0-alpha.17]" />

--- a/src/Xamarin.CodeAnalysis.Remote/Xamarin.CodeAnalysis.Remote.csproj
+++ b/src/Xamarin.CodeAnalysis.Remote/Xamarin.CodeAnalysis.Remote.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
     <PackageReference Include="Microsoft.CodeAnalysis.Remote.ServiceHub" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Remote.Workspaces" />
   </ItemGroup>
 
 </Project>

--- a/src/Xamarin.CodeAnalysis/Xamarin.CodeAnalysis.csproj
+++ b/src/Xamarin.CodeAnalysis/Xamarin.CodeAnalysis.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="GuiLabs.Language.Xml" CopyLocal="true" IncludeInVSIX="true" Pack="true" PackagePath="build\$(TargetFramework)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Remote.ServiceHub" />
     <InternalsVisibleTo Include="Xamarin.CodeAnalysis.Tests" />
   </ItemGroup>
 

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Microsoft.Build.CentralPackageVersions": "2.0.1"
+    "Microsoft.Build.CentralPackageVersions": "2.0.79"
   }
 }

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -5,6 +5,7 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <!-- Compliance: Nuget.config can only have a single feed entry.  The Xamarin.CodeAnalysis feed encapsulates, as upstream feeds, all other feeds needed by the project -->
+    <add key="Xamarin.CodeAnalysis" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Xamarin.CodeAnalysis/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -5,8 +5,6 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="xvssdk" value="https://nugets.blob.core.windows.net/xvssdk/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Replaced by https://github.com/xamarin/CodeAnalysis/pull/7

We've got a new MicroBuild scaleset pool as a replacement for the VSEng-MicroBuildVS2019 pool.  Updating all pipelines to target that pool instead.
https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=2742&view=agents