### PR TITLE
Target windows EO compliant agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ stages:
       inputs:
         solution: Xamarin.CodeAnalysis.sln
         configuration: Release
-        msbuildArguments: /t:restore /bl:"$(Build.ArtifactStagingDirectory)\restore.binlog" /m:1
+        msbuildArguments: /t:restore /bl:"$(Build.ArtifactStagingDirectory)\restore.binlog"
 
     - task: MSBuild@1
       displayName: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,19 +24,17 @@ stages:
     - checkout: self
       clean: true
 
-    - task: MSBuild@1
-      displayName: Restore
+    - task: NuGetAuthenticate@0
+      displayName: Authenticate NuGet feeds
       inputs:
-        solution: Xamarin.CodeAnalysis.sln
-        configuration: Release
-        msbuildArguments: /t:Restore /bl:"$(Build.ArtifactStagingDirectory)\restore.binlog" /m
+        forceReinstallCredentialProvider: true
 
     - task: MSBuild@1
       displayName: Build
       inputs:
         solution: Xamarin.CodeAnalysis.sln
         configuration: Release
-        msbuildArguments: /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:TargetVsixContainer=$(Build.ArtifactStagingDirectory)\Xamarin.CodeAnalysis.vsix /m
+        msbuildArguments: /restore:true /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:TargetVsixContainer=$(Build.ArtifactStagingDirectory)\Xamarin.CodeAnalysis.vsix /m
 
     - task: VSTest@2
       displayName: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,36 +1,55 @@
-queue: VSEng-MicroBuildVS2019
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops
+trigger:
+  batch: false
+  branches:
+    include:
+    - main
 
-steps:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#pr-triggers
+pr:
+  autoCancel: false
+  branches:
+    include:
+    - main
 
-- checkout: self
-  clean: true
+stages:
+- stage: Windows
+  jobs:
+  - job: Build
+    pool:
+      name: AzurePipelines-EO
+      demands:
+      - ImageOverride -equals AzurePipelinesWindows2019compliant
+    steps:
+    - checkout: self
+      clean: true
 
-- task: MSBuild@1
-  displayName: Restore
-  inputs:
-    solution: Xamarin.CodeAnalysis.sln
-    configuration: Release
-    msbuildArguments: /t:Restore /bl:"$(Build.ArtifactStagingDirectory)\restore.binlog" /m
+    - task: MSBuild@1
+      displayName: Restore
+      inputs:
+        solution: Xamarin.CodeAnalysis.sln
+        configuration: Release
+        msbuildArguments: /t:Restore /bl:"$(Build.ArtifactStagingDirectory)\restore.binlog" /m
 
-- task: MSBuild@1
-  displayName: Build
-  inputs:
-    solution: Xamarin.CodeAnalysis.sln
-    configuration: Release
-    msbuildArguments: /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:TargetVsixContainer=$(Build.ArtifactStagingDirectory)\Xamarin.CodeAnalysis.vsix /m
+    - task: MSBuild@1
+      displayName: Build
+      inputs:
+        solution: Xamarin.CodeAnalysis.sln
+        configuration: Release
+        msbuildArguments: /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:TargetVsixContainer=$(Build.ArtifactStagingDirectory)\Xamarin.CodeAnalysis.vsix /m
 
-- task: VSTest@2
-  displayName: Test
-  inputs:
-    testAssemblyVer2: src\*\bin\*\*.Tests.dll
-    runInParallel: 'true'
-    codeCoverageEnabled: 'true'
-    publishRunAttachments: 'true'
+    - task: VSTest@2
+      displayName: Test
+      inputs:
+        testAssemblyVer2: src\*\bin\*\*.Tests.dll
+        runInParallel: 'true'
+        codeCoverageEnabled: 'true'
+        publishRunAttachments: 'true'
 
-- task: PublishBuildArtifacts@1
-  displayName: Publish Artifact
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)
-    ArtifactName: out
-    ArtifactType: Container
-  condition: always()
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact
+      inputs:
+        PathtoPublish: $(Build.ArtifactStagingDirectory)
+        ArtifactName: out
+        ArtifactType: Container
+      condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,11 +30,18 @@ stages:
         forceReinstallCredentialProvider: true
 
     - task: MSBuild@1
+      displayName: Restore
+      inputs:
+        solution: Xamarin.CodeAnalysis.sln
+        configuration: Release
+        msbuildArguments: /t:restore /bl:"$(Build.ArtifactStagingDirectory)\restore.binlog" /m:1
+
+    - task: MSBuild@1
       displayName: Build
       inputs:
         solution: Xamarin.CodeAnalysis.sln
         configuration: Release
-        msbuildArguments: /restore:true /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:TargetVsixContainer=$(Build.ArtifactStagingDirectory)\Xamarin.CodeAnalysis.vsix /m
+        msbuildArguments: /bl:"$(Build.ArtifactStagingDirectory)\build.binlog" /p:TargetVsixContainer=$(Build.ArtifactStagingDirectory)\Xamarin.CodeAnalysis.vsix /m
 
     - task: VSTest@2
       displayName: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
     pool:
       name: AzurePipelines-EO
       demands:
-      - ImageOverride -equals AzurePipelinesWindows2019compliant
+      - ImageOverride -equals AzurePipelinesWindows2022compliant
     steps:
     - checkout: self
       clean: true

--- a/src/Packages.props
+++ b/src/Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <RoslynVersion>3.0.0-beta4-19165-02</RoslynVersion>
+    <RoslynVersion>3.7.0-3.20271.4</RoslynVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Packages.props
+++ b/src/Packages.props
@@ -19,7 +19,7 @@
     <PackageReference Update="xunit" Version="[2.4.0]" />
     <PackageReference Update="xunit.runner.visualstudio" Version="[2.4.0]" />
     <PackageReference Update="GuiLabs.Language.Xml" Version="[1.2.35]" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="[15.0.9]" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="[15.0.16]" />
   </ItemGroup>
 
 </Project>

--- a/src/Packages.props
+++ b/src/Packages.props
@@ -19,6 +19,7 @@
     <PackageReference Update="xunit" Version="[2.4.0]" />
     <PackageReference Update="xunit.runner.visualstudio" Version="[2.4.0]" />
     <PackageReference Update="GuiLabs.Language.Xml" Version="[1.2.35]" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="[15.0.9]" />
   </ItemGroup>
 
 </Project>

--- a/src/Xamarin.CodeAnalysis/Xamarin.CodeAnalysis.csproj
+++ b/src/Xamarin.CodeAnalysis/Xamarin.CodeAnalysis.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="GuiLabs.Language.Xml" CopyLocal="true" IncludeInVSIX="true" Pack="true" PackagePath="build\$(TargetFramework)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
     <InternalsVisibleTo Include="Xamarin.CodeAnalysis.Tests" />
   </ItemGroup>
 

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -5,8 +5,6 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="xvssdk" value="https://nugets.blob.core.windows.net/xvssdk/index.json" />
   </packageSources>
 </configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -5,6 +5,7 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="xvssdk" value="https://nugets.blob.core.windows.net/xvssdk/index.json" />
+    <!-- Compliance: Nuget.config can only have a single feed entry.  The Xamarin.CodeAnalysis feed encapsulates, as upstream feeds, all other feeds needed by the project -->
+    <add key="Xamarin.CodeAnalysis" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Xamarin.CodeAnalysis/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Related work item: VS #[1492239](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1492239)

Per Executive Order (EO) migrate all jobs that currently use a Windows hosted pool to instead use the `AzurePipelines-EO` agent pool instead

Executive Order
https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/buildinfraops